### PR TITLE
뷰 이름변경으로 인한 테스트 수정

### DIFF
--- a/src/test/java/com/example/boardadminproject/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/example/boardadminproject/controller/ArticleCommentManagementControllerTest.java
@@ -27,7 +27,7 @@ class ArticleCommentManagementControllerTest {
         mvc.perform(get("/management/article-comments"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("management/articleComments"));
+                .andExpect(view().name("management/article-comments"));
 
     }
 

--- a/src/test/java/com/example/boardadminproject/controller/UserAccountManagementControllerTest.java
+++ b/src/test/java/com/example/boardadminproject/controller/UserAccountManagementControllerTest.java
@@ -27,7 +27,7 @@ class UserAccountManagementControllerTest {
         mvc.perform(get("/management/user-accounts"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("management/userAccounts"));
+                .andExpect(view().name("management/user-accounts"));
 
     }
 }


### PR DESCRIPTION
유저 관리 페이지와 댓글관리 페이지를 만들면서 뷰 이름을 camel case에서 keba case로 변경함으로써 기존 테스트 결과가 실패가 되었다. 기존 테스트가 통과하게끔 테스트를 수정

This closes #18 