### PR TITLE
댓글 관리 페이지 기능 테스트 정의

### DIFF
--- a/src/main/java/com/example/boardadminproject/dto/ArticleCommentDto.java
+++ b/src/main/java/com/example/boardadminproject/dto/ArticleCommentDto.java
@@ -1,0 +1,25 @@
+package com.example.boardadminproject.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * @author daecheol song
+ * @since 1.0
+ */
+public record ArticleCommentDto(
+        Long id,
+        Long articleId,
+        UserAccountDto userAccount,
+        Long parentCommentId,
+        String content,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static ArticleCommentDto of(Long id, Long articleId, UserAccountDto userAccountDto, Long parentCommentId, String content, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new ArticleCommentDto(id, articleId, userAccountDto, parentCommentId, content, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+}

--- a/src/main/java/com/example/boardadminproject/dto/response/ArticleCommentClientResponse.java
+++ b/src/main/java/com/example/boardadminproject/dto/response/ArticleCommentClientResponse.java
@@ -1,0 +1,42 @@
+package com.example.boardadminproject.dto.response;
+
+import com.example.boardadminproject.dto.ArticleCommentDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * @author daecheol song
+ * @since 1.0
+ */
+public record ArticleCommentClientResponse(
+        @JsonProperty("_embedded") Embedded embedded,
+        @JsonProperty("page") Page page
+) {
+
+    public static ArticleCommentClientResponse empty() {
+        return new ArticleCommentClientResponse(
+                new Embedded(List.of()),
+                new Page(1, 0, 1, 0)
+        );
+    }
+
+    public static ArticleCommentClientResponse of(List<ArticleCommentDto> articleComments) {
+        return new ArticleCommentClientResponse(
+                new Embedded(articleComments),
+                new Page(articleComments.size(), articleComments.size(), 1, 0)
+        );
+    }
+
+    public List<ArticleCommentDto> articleComments() { return this.embedded().articleComments(); }
+
+    public record Embedded(List<ArticleCommentDto> articleComments) {}
+
+    public record Page(
+            int size,
+            long totalElements,
+            int totalPages,
+            int number
+    ) {}
+
+}

--- a/src/main/java/com/example/boardadminproject/service/ArticleCommentManagementService.java
+++ b/src/main/java/com/example/boardadminproject/service/ArticleCommentManagementService.java
@@ -1,0 +1,29 @@
+package com.example.boardadminproject.service;
+
+import com.example.boardadminproject.dto.ArticleCommentDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * @author daecheol song
+ * @since 1.0
+ */
+@RequiredArgsConstructor
+@Service
+public class ArticleCommentManagementService {
+
+    public List<ArticleCommentDto> getArticleComments() {
+        return List.of();
+    }
+
+    public ArticleCommentDto getArticleComment(Long articleCommentId) {
+        return null;
+    }
+
+    public void deleteArticleComment(Long articleCommentId) {
+
+    }
+
+}

--- a/src/test/java/com/example/boardadminproject/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/example/boardadminproject/controller/ArticleCommentManagementControllerTest.java
@@ -2,8 +2,10 @@ package com.example.boardadminproject.controller;
 
 import com.example.boardadminproject.config.SecurityConfig;
 import com.example.boardadminproject.domain.constant.RoleType;
+import com.example.boardadminproject.dto.ArticleCommentDto;
 import com.example.boardadminproject.dto.ArticleDto;
 import com.example.boardadminproject.dto.UserAccountDto;
+import com.example.boardadminproject.service.ArticleCommentManagementService;
 import com.example.boardadminproject.service.ArticleManagementService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,64 +36,66 @@ class ArticleCommentManagementControllerTest {
     private MockMvc mvc;
 
     @MockBean
-    private ArticleManagementService articleManagementService;
+    private ArticleCommentManagementService articleCommentManagementService;
 
     @Test
     @DisplayName("[view][GET] 댓글 관리 페이지 - 정상 호출")
     public void given_whenRequestingArticleCommentManagementView_thenReturnsArticleCommentManagementView() throws Exception {
 
-        given(articleManagementService.getArticles()).willReturn(List.of());
+        given(articleCommentManagementService.getArticleComments()).willReturn(List.of());
 
         mvc.perform(get("/management/article-comments"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("management/article-comments"))
-                .andExpect(model().attribute("articles", List.of()));
-        then(articleManagementService).should().getArticles();
+                .andExpect(model().attribute("articles", List.of()))
+                .andExpect(view().name("management/article-comments"))
+                .andExpect(model().attribute("comments", List.of()));
+        then(articleCommentManagementService).should().getArticleComments();
 
     }
 
-    @DisplayName("[data][GET] 게시글 1개 - 정상 호출")
+
+    @DisplayName("[data][GET] 댓글 1개 - 정상 호출")
     @Test
-    void givenArticleId_whenRequestingArticle_thenReturnsArticle() throws Exception {
+    void givenCommentId_whenRequestingArticleComment_thenReturnsArticleComment() throws Exception {
 
-        Long articleId = 1L;
-        ArticleDto articleDto = createArticleDto("title", "content");
-        given(articleManagementService.getArticle(articleId)).willReturn(articleDto);
+        Long articleCommentId = 1L;
+        ArticleCommentDto articleCommentDto = createArticleCommentDto("comment");
+        given(articleCommentManagementService.getArticleComment(articleCommentId)).willReturn(articleCommentDto);
 
-        mvc.perform(get("/management/articles/" + articleId))
+        mvc.perform(get("/management/article-comments/" + articleCommentId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.id").value(articleId))
-                .andExpect(jsonPath("$.title").value(articleDto.title()))
-                .andExpect(jsonPath("$.content").value(articleDto.content()))
-                .andExpect(jsonPath("$.userAccount.nickname").value(articleDto.userAccount().nickname()));
-        then(articleManagementService).should().getArticle(articleId);
+                .andExpect(jsonPath("$.id").value(articleCommentId))
+                .andExpect(jsonPath("$.content").value(articleCommentDto.content()))
+                .andExpect(jsonPath("$.userAccount.nickname").value(articleCommentDto.userAccount().nickname()));
+        then(articleCommentManagementService).should().getArticleComment(articleCommentId);
     }
 
-    @DisplayName("[view][POST] 게시글 삭제 - 정상 호출")
+    @DisplayName("[view][POST] 댓글 삭제 - 정상 호출")
     @Test
-    void givenArticleId_whenRequestingDeletion_thenRedirectsToArticleManagementView() throws Exception {
+    void givenCommentId_whenRequestingDeletion_thenRedirectsToArticleCommentManagementView() throws Exception {
 
-        Long articleId = 1L;
-        willDoNothing().given(articleManagementService).deleteArticle(articleId);
+        Long articleCommentId = 1L;
+        willDoNothing().given(articleCommentManagementService).deleteArticleComment(articleCommentId);
 
-        mvc.perform(post("/management/articles/" + articleId)
-                        .with(csrf()))
+        mvc.perform(post("/management/article-comments/" + articleCommentId)
+                                .with(csrf()))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(view().name("redirect:/management/articles"))
-                .andExpect(redirectedUrl("/management/articles"));
-        then(articleManagementService).should().deleteArticle(articleId);
+                .andExpect(view().name("redirect:/management/article-comments"))
+                .andExpect(redirectedUrl("/management/article-comments"));
+        then(articleCommentManagementService).should().deleteArticleComment(articleCommentId);
     }
 
 
-    private ArticleDto createArticleDto(String title, String content) {
-        return ArticleDto.of(
+    private ArticleCommentDto createArticleCommentDto(String content) {
+        return ArticleCommentDto.of(
+                1L,
                 1L,
                 createUserAccountDto(),
-                title,
-                content,
                 null,
+                content,
                 LocalDateTime.now(),
                 "Song",
                 LocalDateTime.now(),

--- a/src/test/java/com/example/boardadminproject/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/example/boardadminproject/controller/ArticleManagementControllerTest.java
@@ -1,24 +1,38 @@
 package com.example.boardadminproject.controller;
 
 import com.example.boardadminproject.config.SecurityConfig;
+import com.example.boardadminproject.domain.constant.RoleType;
+import com.example.boardadminproject.dto.ArticleDto;
+import com.example.boardadminproject.dto.UserAccountDto;
+import com.example.boardadminproject.service.ArticleManagementService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@DisplayName("View 컨트롤러 - 게시글 관리")
+@DisplayName("컨트롤러 - 게시글 관리")
 @Import(SecurityConfig.class)
 @WebMvcTest
 class ArticleManagementControllerTest {
 
     @Autowired
     private MockMvc mvc;
+
+    @MockBean
+    private ArticleManagementService articleManagementService;
 
     @Test
     @DisplayName("[view][GET] 게시글 관리 페이지 - 정상 호출")
@@ -29,5 +43,64 @@ class ArticleManagementControllerTest {
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("management/articles"));
 
+    }
+
+    @DisplayName("[data][GET] 게시글 1개 - 정상 호출")
+    @Test
+    void givenArticleId_whenRequestingArticle_thenReturnsArticle() throws Exception {
+
+        Long articleId = 1L;
+        ArticleDto articleDto = createArticleDto("title", "content");
+        given(articleManagementService.getArticle(articleId)).willReturn(articleDto);
+
+        mvc.perform(get("/management/articles/" + articleId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(articleId))
+                .andExpect(jsonPath("$.title").value(articleDto.title()))
+                .andExpect(jsonPath("$.content").value(articleDto.content()))
+                .andExpect(jsonPath("$.userAccount.nickname").value(articleDto.userAccount().nickname()));
+        then(articleManagementService).should().getArticle(articleId);
+    }
+
+    @DisplayName("[view][POST] 게시글 삭제 - 정상 호출")
+    @Test
+    void givenArticleId_whenRequestingDeletion_thenRedirectsToArticleManagementView() throws Exception {
+
+        Long articleId = 1L;
+        willDoNothing().given(articleManagementService).deleteArticle(articleId);
+
+        mvc.perform(post("/management/articles/" + articleId)
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/management/articles"))
+                .andExpect(redirectedUrl("/management/articles"));
+        then(articleManagementService).should().deleteArticle(articleId);
+    }
+
+
+    private ArticleDto createArticleDto(String title, String content) {
+        return ArticleDto.of(
+                1L,
+                createUserAccountDto(),
+                title,
+                content,
+                null,
+                LocalDateTime.now(),
+                "Song",
+                LocalDateTime.now(),
+                "Song"
+        );
+    }
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
+                "tester",
+                "pw",
+                Set.of(RoleType.ADMIN),
+                "tester@email.com",
+                "tester",
+                "test memo"
+        );
     }
 }

--- a/src/test/java/com/example/boardadminproject/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/example/boardadminproject/service/ArticleCommentManagementServiceTest.java
@@ -1,0 +1,167 @@
+package com.example.boardadminproject.service;
+
+import com.example.boardadminproject.domain.constant.RoleType;
+import com.example.boardadminproject.dto.ArticleCommentDto;
+import com.example.boardadminproject.dto.UserAccountDto;
+import com.example.boardadminproject.dto.properties.ProjectProperties;
+import com.example.boardadminproject.dto.response.ArticleCommentClientResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * @author daecheol song
+ * @since 1.0
+ */
+@ActiveProfiles("test")
+@DisplayName("비즈니스 로직 - 댓글 관리")
+public class ArticleCommentManagementServiceTest {
+
+    @Disabled("실제 API 호출 결과 관찰용이므로 평상시엔 비활성화")
+    @DisplayName("실제 API 호출 테스트")
+    @SpringBootTest
+    @Nested
+    class RealApiTest {
+
+        @Autowired
+        private ArticleCommentManagementService sut;
+
+
+        @DisplayName("댓글 API를 호출하면, 댓글을 가져온다.")
+        @Test
+        void givenNothing_whenCallingCommentApi_thenReturnsCommentList() {
+
+            List<ArticleCommentDto> result = sut.getArticleComments();
+
+            assertThat(result).isNotNull();
+        }
+    }
+
+    @DisplayName("API mocking 테스트")
+    @EnableConfigurationProperties(ProjectProperties.class)
+    @AutoConfigureWebClient(registerRestTemplate = true)
+    @RestClientTest(ArticleCommentManagementService.class)
+    @Nested
+    class RestTemplateTest {
+
+        @Autowired
+        private ArticleCommentManagementService sut;
+
+        @Autowired
+        private ProjectProperties properties;
+
+        @Autowired
+        private MockRestServiceServer server;
+
+        @Autowired
+        private ObjectMapper mapper;
+
+
+        @DisplayName("댓글 목록 API을 호출하면, 댓글들을 가져온다.")
+        @Test
+        void givenNothing_whenCallingCommentsApi_thenReturnsComments() throws Exception {
+
+            ArticleCommentDto expectedComment = createArticleCommentDto("댓글");
+            ArticleCommentClientResponse expectedResponse = ArticleCommentClientResponse.of(List.of(expectedComment));
+            server
+                    .expect(requestTo(properties.board().url() + "/api/articleComments?size=10000"))
+                    .andRespond(withSuccess(
+                            mapper.writeValueAsString(expectedResponse),
+                            MediaType.APPLICATION_JSON
+                    ));
+
+
+            List<ArticleCommentDto> result = sut.getArticleComments();
+
+            assertThat(result).first()
+                    .hasFieldOrPropertyWithValue("id", expectedComment.id())
+                    .hasFieldOrPropertyWithValue("content", expectedComment.content())
+                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedComment.userAccount().nickname());
+            server.verify();
+        }
+
+        @DisplayName("댓글 ID와 함께 댓글 API을 호출하면, 댓글을 가져온다.")
+        @Test
+        void givenCommentId_whenCallingCommentApi_thenReturnsComment() throws Exception {
+            Long articleCommentId = 1L;
+            ArticleCommentDto expectedComment = createArticleCommentDto("댓글");
+            server
+                    .expect(requestTo(properties.board().url() + "/api/articleComments/" + articleCommentId))
+                    .andRespond(withSuccess(
+                            mapper.writeValueAsString(expectedComment),
+                            MediaType.APPLICATION_JSON
+                    ));
+
+
+            ArticleCommentDto result = sut.getArticleComment(articleCommentId);
+
+            assertThat(result)
+                    .hasFieldOrPropertyWithValue("id", expectedComment.id())
+                    .hasFieldOrPropertyWithValue("content", expectedComment.content())
+                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedComment.userAccount().nickname());
+            server.verify();
+        }
+
+        @DisplayName("댓글 ID와 함께 댓글 삭제 API을 호출하면, 댓글을 삭제한다.")
+        @Test
+        void givenCommentId_whenCallingDeleteCommentApi_thenDeletesComment() throws Exception {
+
+            Long articleCommentId = 1L;
+            server
+                    .expect(requestTo(properties.board().url() + "/api/articleComments/" + articleCommentId))
+                    .andExpect(method(HttpMethod.DELETE))
+                    .andRespond(withSuccess());
+
+            sut.deleteArticleComment(articleCommentId);
+
+            server.verify();
+        }
+    }
+
+
+    private ArticleCommentDto createArticleCommentDto(String content) {
+        return ArticleCommentDto.of(
+                1L,
+                1L,
+                createUserAccountDto(),
+                null,
+                content,
+                LocalDateTime.now(),
+                "Song",
+                LocalDateTime.now(),
+                "Song"
+        );
+    }
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
+                "tester",
+                "pw",
+                Set.of(RoleType.ADMIN),
+                "tester@email.com",
+                "tester",
+                "test memo"
+        );
+    }
+
+}

--- a/src/test/java/com/example/boardadminproject/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/example/boardadminproject/service/ArticleManagementServiceTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 


### PR DESCRIPTION
This closes #24  
- test 는 현재 `articleCommentService` 의  세부 비지니스 로직 구현과 컨트롤러 구현이 미완성인 상태이므로 실패한다.
- 기존에 게시글 관리 테스트를 댓글 관리 테스트 위치에 작성을 해버렸다. 그래서 다시 위치를 제자리로 돌려놓고 댓글 관리 테스트를 작성.