### PR TITLE
다크모드 구현

### DIFF
--- a/src/main/resources/static/css/docs.css
+++ b/src/main/resources/static/css/docs.css
@@ -1,0 +1,52 @@
+.max-height-300 pre {
+    max-height: 300px;
+}
+
+.theme-switch {
+    display: inline-block;
+    height: 24px;
+    position: relative;
+    width: 50px;
+}
+
+.theme-switch input {
+    display: none;
+}
+
+.slider {
+    background-color: #ccc;
+    bottom: 0;
+    cursor: pointer;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    transition: 400ms;
+}
+
+.slider::before {
+    background-color: #fff;
+    bottom: 4px;
+    content: "";
+    height: 16px;
+    left: 4px;
+    position: absolute;
+    transition: 400ms;
+    width: 16px;
+}
+
+input:checked + .slider {
+    background-color: #66bb6a;
+}
+
+input:checked + .slider::before {
+    transform: translateX(26px);
+}
+
+.slider.round {
+    border-radius: 34px;
+}
+
+.slider.round::before {
+    border-radius: 50%;
+}

--- a/src/main/resources/templates/layouts/layout-head.html
+++ b/src/main/resources/templates/layouts/layout-head.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
     <link rel="stylesheet" href="/js/plugins/fontawesome-free/css/all.min.css">
     <link rel="stylesheet" href="/css/adminlte.min.css">
-
+    <link rel="stylesheet" href="/css/docs.css">
     <!--/* 페이지 전용 스타일 */-->
     <link id="head-links">
 </head>

--- a/src/main/resources/templates/layouts/layout-header.html
+++ b/src/main/resources/templates/layouts/layout-header.html
@@ -164,6 +164,17 @@
                     <i class="fas fa-th-large"></i>
                 </a>
             </li>
+
+            <!--/* 다크모드 토글 버튼 */-->
+            <li class="nav-item">
+                <div class="theme-switch-wrapper nav-link">
+                    <label class="theme-switch" for="dark-mode-checkbox">
+                        <input type="checkbox" id="dark-mode-checkbox">
+                        <span class="slider round"></span>
+                    </label>
+                </div>
+            </li>
+
         </ul>
     </nav>
 </header>

--- a/src/main/resources/templates/layouts/layout-main-table.html
+++ b/src/main/resources/templates/layouts/layout-main-table.html
@@ -5,7 +5,7 @@
     <title>공통 메인 컨텐츠 (테이블형)</title>
 </head>
 <body>
-<main id="layout-main" class="content-wrapper">
+<main id="layout-main" class="content-wrapper accent-dark">
     <!-- Content Header (Page header) -->
     <div class="content-header">
         <div class="container-fluid">

--- a/src/main/resources/templates/layouts/layout-scripts.html
+++ b/src/main/resources/templates/layouts/layout-scripts.html
@@ -8,5 +8,45 @@
 <script src="/js/plugins/jquery/jquery.min.js"></script>
 <script src="/js/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
 <script src="/js/adminlte.min.js"></script>
+<script>
+    $(document).ready(() => {
+        if (sessionStorage.getItem('darkMode') === "true") {
+            $('body').addClass('dark-mode');
+            $('header nav')
+                .addClass('navbar-dark')
+                .removeClass('navbar-light');
+            $('main, footer')
+                .addClass('accent-light')
+                .removeClass('accent-dark');
+            $('.modal-body pre').addClass('text-light');
+            $('#dark-mode-checkbox').prop('checked', true);
+        }
+    })
+
+
+    $('#dark-mode-checkbox').on('click', function() {
+        if ($(this).is(':checked')) {
+            $('body').addClass('dark-mode');
+            $('header nav')
+                .addClass('navbar-dark')
+                .removeClass('navbar-light');
+            $('main, footer')
+                .addClass('accent-light')
+                .removeClass('accent-dark');
+            $('.modal-body pre').addClass('text-light');
+            sessionStorage.setItem('darkMode', "true");
+        } else {
+            $('body').removeClass('dark-mode');
+            $('header nav')
+                .addClass('navbar-light')
+                .removeClass('navbar-dark');
+            $('main, footer')
+                .addClass('accent-dark')
+                .removeClass('accent-light');
+            $('.modal-body pre').removeClass('text-light');
+            sessionStorage.setItem('darkMode', "false");
+        }
+    });
+</script>
 </body>
 </html>


### PR DESCRIPTION
AdminLTE 에서 다크모드 기능을 제공하고 있고, 이 기능을 활용하여 게시판에 다크모드를 적용.

SessionStorage에 다크모드 여부 값을 저장하고 `document.ready()`시에 이 값에 따라 다크모드를 적용한다. 이로 인해 다크모드로 설정된후 브라우저를 로딩초기에 기존 화이트모드였다가 로딩다 된후 다크모드로 전환되는 깜빡이는 현상이 있는데 다크모드로 설정되어있을때, 로딩 초기부터 다크모드로 보여주는 기능이 필요해보인다.

This closes #50 